### PR TITLE
Update crypttest benchmarks and validation suits to remove sha3 for now.

### DIFF
--- a/src/third_party_libs/cryptopp/bench.cpp
+++ b/src/third_party_libs/cryptopp/bench.cpp
@@ -279,10 +279,6 @@ void BenchmarkAll(double t, double hertz)
 	BenchMarkByNameKeyLess<HashTransformation>("SHA-1");
 	BenchMarkByNameKeyLess<HashTransformation>("SHA-256");
 	BenchMarkByNameKeyLess<HashTransformation>("SHA-512");
-	BenchMarkByNameKeyLess<HashTransformation>("SHA-3-224");
-	BenchMarkByNameKeyLess<HashTransformation>("SHA-3-256");
-	BenchMarkByNameKeyLess<HashTransformation>("SHA-3-384");
-	BenchMarkByNameKeyLess<HashTransformation>("SHA-3-512");
 	BenchMarkByNameKeyLess<HashTransformation>("Tiger");
 	BenchMarkByNameKeyLess<HashTransformation>("Whirlpool");
 	BenchMarkByNameKeyLess<HashTransformation>("RIPEMD-160");

--- a/src/third_party_libs/cryptopp/validat1.cpp
+++ b/src/third_party_libs/cryptopp/validat1.cpp
@@ -55,7 +55,6 @@ bool ValidateAll(bool thorough)
 	pass=ValidateMD2() && pass;
 	pass=ValidateMD5() && pass;
 	pass=ValidateSHA() && pass;
-	pass=RunTestDataFile("TestVectors/sha3.txt") && pass;
 	pass=ValidateTiger() && pass;
 	pass=ValidateRIPEMD() && pass;
 	pass=ValidatePanama() && pass;


### PR DESCRIPTION
Test branch still to validate under all checkers and sanitizer tests. Passing all included unit and functional tests. 
