### PR TITLE
Update Readme: remove githalytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,3 @@ For full details about the MaidSafe platform, see the [wiki] (https://github.com
 To get started quickly, jump straight to the [build instructions] (https://github.com/maidsafe/MaidSafe/wiki/Build-Instructions).
 
 Or to discuss any aspect of any MaidSafe library, use the [developers mailing list] (https://groups.google.com/forum/#!forum/maidsafe-development).
-
-[![githalytics.com alpha](https://cruel-carlota.pagodabox.com/a7b68d398193904dc9d31ab4a0ecd6d1 "githalytics.com")](http://githalytics.com/maidsafe/MaidSafe)


### PR DESCRIPTION
remove githalytics.com because the site seems to be down.
